### PR TITLE
fix: disable scroll y when sign in is on page

### DIFF
--- a/javascript/signInUp.js
+++ b/javascript/signInUp.js
@@ -41,7 +41,15 @@ function clickSignInButton() {
     signInBtn.classList.remove("animationSignIn")
     signInBtn.classList.toggle("animationOffSignIn")
   }
+
   signInBtn.classList.toggle("animationSignIn")
+
+  signInBtn.classList.toggle("disable-scroll-y")
+  document.body.style.overflowY = "auto";
+
+  if (signInBtn.classList.contains("disable-scroll-y")) {
+    document.body.style.overflowY = "hidden";
+  }
 
   if(signInBtn.classList.contains("animationOffSignIn")) {
     setTimeout(function() {


### PR DESCRIPTION
### Pull Request Information

**Issue Number**: #114 

**Description of Changes**:

I worked on a fix to disable vertical scroll on Sign in page

**Screenshots/GIFs**:

The scroll is disabled when the sign-in page is shown

![image](https://github.com/c4coderandcreator/Flavour-Fusion/assets/48018975/bcae4df1-f524-4f1b-ad61-d2517318f215)

It is re-enabled when home page is shown

![image](https://github.com/c4coderandcreator/Flavour-Fusion/assets/48018975/d18eb820-b87e-42b1-879b-eb8da05ab844)


### Checklist

Please make sure that your PR meets the following requirements:

- [x ] Code is well-documented.
- [ x] Code follows the project's coding style and standards.
- [ ] New code includes relevant unit tests (if applicable).
- [ ] Existing tests have been updated (if applicable).
- [ x] The PR has been reviewed for correctness and quality.
- [x ] The PR is up-to-date with the latest changes from the main branch.
- [x ] The PR does not introduce new issues or conflicts.

### Additional Notes

N/A

### Reviewers

Please tag any specific team members or contributors who should review this pull request. For general review, you can use `@flavour-fusion/team`.

### Checklist for Reviewers

- [x] The code changes are correct and functional.
- [x] Code adheres to project coding style and standards.
- [ ] Unit tests (if applicable) have been added or updated.
- [ ] The code does not introduce new issues or conflicts.
- [x] All relevant changes have been documented in the project's documentation (if applicable).

### By submitting this pull request, I confirm that I have read and agree to the [Contributor License Agreement](CONTRIBUTING.md), and I'm submitting this code in accordance with the terms of that agreement.
